### PR TITLE
Cleanup CMake build system using find_package() commands for required libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ add_definitions(-std=c++0x)
 if(OPT_BOOST_STATIC)
 	set(Boost_USE_STATIC_LIBS ON)
 	# we need zlib to link boost iostreams statically
-	find_library(Z z)
+	find_package(ZLIB REQUIRED)
 endif()
 
 find_package(Boost COMPONENTS iostreams system filesystem program_options REQUIRED)
@@ -36,17 +36,7 @@ if(NOT OPT_SKIP_TESTS)
 endif()
 include_directories(${Boost_INCLUDE_DIRS})
 
-find_library(PTHREAD pthread)
-find_library(PNG png)
-
-if("${PTHREAD}" EQUAL "PTHREAD-NOTFOUND")
-    message(FATAL_ERROR "libpthread not found!")
-endif()
-if("${PNG}" EQUAL "PNG-NOTFOUND")
-    message(FATAL_ERROR "libpng not found!")
-endif()
-if(OPT_BOOST_STATIC AND "${Z}" EQUAL "Z-NOTFOUND")
-	message(FATAL_ERROR "zlib not found!")
-endif()
+find_package(Threads REQUIRED)
+find_package(PNG REQUIRED)
 
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/src")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,10 +62,10 @@ if(NOT OPT_SKIP_TESTS)
 	target_link_libraries(mapcraftercore ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 endif()
 
-target_link_libraries(mapcraftercore png)
-target_link_libraries(mapcraftercore pthread)
+target_link_libraries(mapcraftercore ${PNG_LIBRARIES})
+target_link_libraries(mapcraftercore ${CMAKE_THREAD_LIBS_INIT})
 if(OPT_BOOST_STATIC)
-	target_link_libraries(mapcraftercore z)
+	target_link_libraries(mapcraftercore ${ZLIB_LIBRARIES})
 endif()
 
 add_executable(mapcrafter mapcrafter.cpp)


### PR DESCRIPTION
Changes in this patch:
- Instead of looking for binaries, we look for the entire package using the CMake `find_package()` command.  This will find libraries and include files.
- We skip the failure detection, because the `REQUIRED` parameter to `find_package()` fall if the command cannot be found.

Tested on Debian x64 Sid, using CMake 2.8.11.2.  Properly fails when the packages are not completely found (i.e., when the header files cannot be found, even if the library binaries can).  I do not have CMake 2.6 on hand to test this patch, but since it is the minimum required version, this patch should be tested with it before merging.
