### PR TITLE
Set UTF8 Encoding via meta-Tag in index.html

### DIFF
--- a/src/data/template/index.html
+++ b/src/data/template/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<title>Minecraft Map</title>
 		<meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
+		<meta http-equiv="Content-type" content="text/html;charset=UTF-8">
 		<link rel="stylesheet" type="text/css" href="static/css/style.css" />
 		<link rel="stylesheet" href="static/leaflet/leaflet.css" />
 		<!--[if lte IE 8]>


### PR DESCRIPTION
Hi @m0r13,

If you write signs in german with Umlauts the Encoding is broken in markers. I quickly fixed that with adding an meta-Tag for Content-Type to the index.html. :wink:  
