### PR TITLE
Added _WIN32/64 for use with Visual Studio

### DIFF
--- a/src/util/filesystem.cpp
+++ b/src/util/filesystem.cpp
@@ -28,7 +28,7 @@
   #include <mach-o/dyld.h>
 #elif defined(__FreeBSD__)
   #include <sys/sysctl.h>
-#elif defined(__WIN32__) || defined(__WIN64__)
+#elif defined(__WIN32__) || defined(__WIN64__) || defined(_WIN32) || defined(_WIN64)
   #include <windows.h>
 #endif
 
@@ -79,7 +79,7 @@ bool moveFile(const fs::path& from, const fs::path& to) {
 // TODO make sure this works on different OSes
 fs::path findHomeDir() {
 	char* path;
-#if defined(__WIN32__) || defined(__WIN64__)
+#if defined(__WIN32__) || defined(__WIN64__) || defined(_WIN32) || defined(_WIN64)
 	path = getenv("APPDATA");
 #else
 	path = getenv("HOME");
@@ -114,7 +114,7 @@ fs::path findExecutablePath() {
 	int len;
 	if ((len = readlink("/proc/self/exe", buf, sizeof(buf))) != -1)
 		return fs::path(std::string(buf, len));
-#elif defined(__WIN32__) || defined(__WIN64__)
+#elif defined(__WIN32__) || defined(__WIN64__) || defined(_WIN32) || defined(_WIN64)
 	GetModuleFileName(NULL, buf, 1024);
 	return fs::path(std::string(buf));
 #else


### PR DESCRIPTION
Turns out, VS uses _WIN32 and _WIN64 instead of __WIN32__ and **WIN64**
