### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ to add your own map to this list.
 ## Documentation and Help ##
 
 The documentation is in the `docs/` directory and you can build it yourself
-with Sphinx. You can read a built version of the documentation
-[here](http://docs.mapcrafter.org) and you can also [download
+with Sphinx. You can read a built version of the documentation on
+[docs.mapcrafter.org](http://docs.mapcrafter.org) and you can also [download
 other builds](https://readthedocs.org/projects/mapcrafter/downloads/).
 
 If you find bugs or problems when using Mapcrafter or if you have ideas for new


### PR DESCRIPTION
change `here` to `on docs.mapcrafter.org` to improve readability and follow best practices for linking to various things.

Ref:

> For example, links that either have general text such as "More" or "Click Here", or that occur multiple times on the same page, such as "Delete" or "Edit", should be avoided in favor of links that provide text specific to the target of the link.
> 
> -- <cite>https://www.webaccessibility.com/best_practices.php?technology_platform_id=5
