### PR TITLE
EndPortal and Convert functionality fixed in mapcrafter_texture.py

### DIFF
--- a/src/tools/mapcrafter_textures.py
+++ b/src/tools/mapcrafter_textures.py
@@ -18,11 +18,13 @@ files = [
 	("entity/chest/trapped_double.png", assets + "entity/chest/trapped_double.png"),
 	("colormap/foliage.png", assets + "colormap/foliage.png"),
 	("colormap/grass.png", assets + "colormap/grass.png"),
+        ("endportal.png", assets + "entity/end_portal.png")
 ]
 
 def has_imagemagick():
 	try:
 		subprocess.check_output("convert")
+                return True
 	except subprocess.CalledProcessError:
 		return True
 	except OSError as e:


### PR DESCRIPTION
Fixed mapcrafter_textures to export the endportal.png properly and find the convert command properly.