### PR TITLE
Refer to the RFC

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -67,7 +67,7 @@ The following options are relevant for all log sink types.
     **Default:** ``INFO``
     
     This is the verbosity of the log sink, i.e. the minimum log level a message must
-    have to be handled by the log sink. Available log levels are (according to syslog):
+    have to be handled by the log sink. Available log levels are (according to RFC 5424):
     
     * ``DEBUG``, ``INFO``, ``NOTICE``, ``WARNING``, ``ERROR``, ``FATAL``, ``ALERT``,
       ``EMERGENCY``

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -67,7 +67,7 @@ The following options are relevant for all log sink types.
     **Default:** ``INFO``
     
     This is the verbosity of the log sink, i.e. the minimum log level a message must
-    have to be handled by the log sink. Available log levels are (according to RFC 5424):
+    have to be handled by the log sink. Available log levels are (according to `RFC 5424 <https://tools.ietf.org/html/rfc5424>`_ ):
     
     * ``DEBUG``, ``INFO``, ``NOTICE``, ``WARNING``, ``ERROR``, ``FATAL``, ``ALERT``,
       ``EMERGENCY``


### PR DESCRIPTION
Makes more sense to refer to the RFC that defines it than "syslog", because reasons.