### PR TITLE
Override icons and icon sizes per marker.

### DIFF
--- a/docs/markers.rst
+++ b/docs/markers.rst
@@ -85,6 +85,10 @@ Here is an example ``markers.js`` file:
                         "title" : "Sign1",
                         // text in the marker popup window
                         "text" : "Hello."
+                        // override the icon of a single marker (optional)
+                        "icon" : "player.png",
+                        // override the size of the marker icon (optional)
+                        "iconSize" : [16, 32]
                     },
                     // more markers:
                     {"pos" : [100, 100, 64], "title" : "Test1"},
@@ -156,8 +160,28 @@ Here are the available options for the markers:
 
 	**Default:** *Title of the marker*
 
-	This is the text of the marker popup window. 
-	If you do not specifiy a text, the title of the marker is used as text.
+	This is the text of the marker popup window.
+	If you do not specify a text, the title of the marker is used as text.
+
+``icon``
+
+    **Default:** *Group icon*
+
+    An override for the icon for this specific marker.
+    If you do not specify an icon, the icon set at the group level is used. Or,
+    if there is no group-level icon, the default icon is used.
+
+    This option may be used independently of the marker icon size override.
+
+``iconSize``
+
+    **Default:** *Group icon size*
+
+    An override for the size of the icon for this specific marker.
+    If you do not specify a size, the icon size set at the group level is used.
+    Or, if there is no group-level icon size, the default icon size is used.
+
+    This option may be used independently of the marker icon override.
 
 Furthermore you can customize your markers by specifying a function which
 creates the actual Leaflet marker objects with the marker data. This function

--- a/src/data/template/markers.js
+++ b/src/data/template/markers.js
@@ -25,7 +25,11 @@ var MAPCRAFTER_MARKERS = [
 					// title when you hover over the marker
 					"title" : "Sign1",
 					// text in the marker popup window
-					"text" : "Hello."
+					"text" : "Hello.",
+					// override the icon of a single marker (optional)
+					"icon" : "player.png",
+					// override the size of the marker icon (optional)
+					"iconSize" : [32, 32]
 				},
 				// more markers:
 				{"pos" : [100, 100, 64], "title" : "Test1"},

--- a/src/data/template/static/js/handler/marker.js
+++ b/src/data/template/static/js/handler/marker.js
@@ -19,10 +19,18 @@ MarkerHandler.prototype.onMapChange = function(name, rotation) {
 		var marker = new L.Marker(ui.mcToLatLng(pos[0], pos[1], pos[2]), {
 			title: markerInfo.title,
 		});
-		if(groupInfo.icon) {
+
+		// The icon may be specified on either a marker or group level, with
+		// preference for the marker-specific icon.
+		var icon = markerInfo.icon ? markerInfo.icon : groupInfo.icon;
+		var iconSize = markerInfo.iconSize ? markerInfo.iconSize : groupInfo.iconSize;
+
+		if(icon) {
 			marker.setIcon(new L.Icon({
-				iconUrl: groupInfo.icon != "" ? "static/markers/" + groupInfo.icon : null,
-				iconSize: (groupInfo.iconSize ? groupInfo.iconSize : [24, 24]),
+				// The icon URL itself may be given relative to "static/markers"
+				// or as an absolute URL (perhaps to a resource on a CDN).
+				iconUrl: icon.match(/^\w+:\/\//) ? icon : "static/markers/" + icon,
+				iconSize: (iconSize ? iconSize : [24, 24]),
 			}));
 		}
 		marker.bindPopup(markerInfo.text ? markerInfo.text : markerInfo.title);


### PR DESCRIPTION
It would be really nice to be able to set the icons of each marker in a group individually, while still being able to set an icon for the whole group if so desired. The featured use-case for this is player markers: all player markers being part of the same group so a user can show or hide all of the markers at once, but each marker icon being the associated player's skin.

An example of this in action can be found on [this Mapcrafter instance](http://seecraft.seenet.ca/).