### PR TITLE
Extract the end portal texture from the client.

### DIFF
--- a/src/tools/mapcrafter_textures.py
+++ b/src/tools/mapcrafter_textures.py
@@ -18,6 +18,7 @@ files = [
 	("entity/chest/trapped_double.png", assets + "entity/chest/trapped_double.png"),
 	("colormap/foliage.png", assets + "colormap/foliage.png"),
 	("colormap/grass.png", assets + "colormap/grass.png"),
+	("endportal.png", assets + "entity/end_portal.png"),
 ]
 
 def has_imagemagick():


### PR DESCRIPTION
Noticed this while building and installing from source. The [documentation](http://docs.mapcrafter.org/builds/stable/installation.html) notes that a texture named `endportal.png` is required by Mapcrafter, but the shipping `mapcrafter_textures.py` doesn't actually pull the file out of the client JAR, resulting in map generation failure and this error message:

    2015-07-27 18:55:11 [ERROR] [default] Unable to read '/home/minecraft/.mapcrafter/textures/endportal.png'.
    2015-07-27 18:55:11 [ERROR] [default] Invalid texture directory '/home/minecraft/.mapcrafter/textures'. See previous log messages.
    2015-07-27 18:55:11 [ERROR] [default] Skipping remaining rotations.

This patch fixes the texture extraction script to pull the end portal texture out of the JAR.