### PR TITLE
Documentation and error message tweak for spawn overlay

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -423,7 +423,7 @@ Map Options
     Therefore you can still use it in old configuration files, but Mapcrafter
     will show a warning.
 
-``overlay = slime|spawn``
+``overlay = slime|spawnday|spawnnight``
 
     **Default:** ``none``
 

--- a/src/mapcraftercore/config/configsections/map.cpp
+++ b/src/mapcraftercore/config/configsections/map.cpp
@@ -68,7 +68,8 @@ renderer::OverlayType as<renderer::OverlayType>(const std::string& from) {
 		return renderer::OverlayType::SPAWNDAY;
 	else if (from == "spawnnight")
 		return renderer::OverlayType::SPAWNNIGHT;
-	throw std::invalid_argument("Must be 'none', 'slime' or 'spawn'!");
+	throw std::invalid_argument("Must be 'none', 'slime', 'spawnday', or "
+			"'spawnnight'!");
 }
 
 }


### PR DESCRIPTION
I was stoked to see the new overlay stuff when I upgraded to 2.0. Tried to use the spawn version and it was giving an error saying I had to use `spawn` which I totally was. I dove into the source and saw the message fell out of line with reality, so I figured I'd fix that. I also updated the docs to reflect the change.