### PR TITLE
Enable map selection on mobile devices. Fixes #123

### DIFF
--- a/src/data/template/static/js/control/mapselect.js
+++ b/src/data/template/static/js/control/mapselect.js
@@ -29,6 +29,7 @@ MapSelectControl.prototype.create = function(wrapper) {
 	var text = document.createElement("span");
 	text.innerHTML = "Map type: ";
 	
+	L.DomEvent.disableClickPropagation(wrapper);
 	wrapper.appendChild(text);
 	wrapper.appendChild(select);
 };


### PR DESCRIPTION
Based on https://github.com/Leaflet/Leaflet/issues/1978 and https://github.com/Leaflet/Leaflet/issues/2699, this allows mobile browser to present the user with the choice of which map they want when they tap the drop-down.

I have tested this code my manually updating the .js file in my mapcrafter instance, and it has worked correctliy on Safari in iOS, and Chrome and Firefox on Android. Behavior of desktop browsers (Chrome and Firefox on both OSX and Linux) is unchanged.  (To be clear, I have not locally compiled mapcrafter with this change.)