### PR TITLE
Fix checks for include files with clang.

### DIFF
--- a/src/mapcraftercore/CMakeLists.txt
+++ b/src/mapcraftercore/CMakeLists.txt
@@ -3,6 +3,7 @@ set(CMAKE_REQUIRED_FLAGS -std=c++0x)
 CHECK_CXX_SOURCE_COMPILES("int main() { void* p = nullptr; }" HAVE_NULLPTR)
 CHECK_CXX_SOURCE_COMPILES("enum class Test { A=0, B=1, C=3 }; int main() { Test::A < Test::C; }" HAVE_ENUM_CLASS_COMPARISON)
 CHECK_CXX_SOURCE_COMPILES("enum class Test; enum class Test { A, B }; int main() { Test::A == Test::B; }" HAVE_ENUM_CLASS_FORWARD_DECLARATION)
+set(CMAKE_REQUIRED_FLAGS)
 
 INCLUDE(CheckIncludeFiles)
 CHECK_INCLUDE_FILES("endian.h" HAVE_ENDIAN_H)


### PR DESCRIPTION
Without this, the -std=c++0x flag is carried forward and used with cc. This results in an error:

```
/usr/bin/cc    -O2 -pipe  -fstack-protector -fno-strict-aliasing -std=c++0x   -o CMakeFiles/cmTC_2844e.dir/CheckIncludeFiles.c.o   -c /usr/ports/games/mapcrafter/work/mapcrafter-v.2.2.1/CMakeFiles/CMakeTmp/CheckIncludeFiles.c
error: invalid argument '-std=c++0x' not allowed with 'C/ObjC'
```

I think this only happens with clang (FreeBSD 10), because won FreeBSD 9 which has GCC it's fine.

I'm no CMake expert - but this appears to work :-)