### PR TITLE
FIX(World) adding getRegionNoCrop for global cache update

### DIFF
--- a/src/mapcraftercore/mc/world.cpp
+++ b/src/mapcraftercore/mc/world.cpp
@@ -160,5 +160,15 @@ bool World::getRegion(const RegionPos& pos, RegionFile& region) const {
 	return true;
 }
 
+
+bool World::getRegionNoCrop(const RegionPos &pos, RegionFile &region) const {
+	RegionMap::const_iterator it = region_files.find(pos);
+	if (it == region_files.end())
+		return false;
+	region = RegionFile(it->second);
+	region.setRotation(rotation);
+	return true;
+}
+
 }
 }

--- a/src/mapcraftercore/mc/world.h
+++ b/src/mapcraftercore/mc/world.h
@@ -140,6 +140,15 @@ public:
 	 */
 	bool getRegion(const RegionPos& pos, RegionFile& region) const;
 
+	/**
+	 * Creates the Region-object for a specific region and assigns the supplied reference
+	 * 'region' to it. This variant ignore world's defined crop. It should be used specifically
+	 * for updating the cache, to prevent, crop boundaries affected regions to not be updated.
+	 * Returns false if the region does not exist.
+	 */
+	bool getRegionNoCrop(const RegionPos& pos, RegionFile& region) const;
+
+
 private:
 	// world directory, region directory
 	fs::path world_dir, region_dir;

--- a/src/mapcraftercore/mc/worldentities.cpp
+++ b/src/mapcraftercore/mc/worldentities.cpp
@@ -221,7 +221,7 @@ void WorldEntitiesCache::update(util::IProgressHandler* progress) {
 		}
 
 		RegionFile region;
-		world.getRegion(*region_it, region);
+		world.getRegionNoCrop(*region_it, region);
 		region.read();
 
 		auto chunks = region.getContainingChunks();


### PR DESCRIPTION
~~
Cause:
    If render.conf contained multiple definitions of the same world with some
    crop setting it would cause cache to mistakenly update timestamp on whole
    region but some entities would left out because of cropping is not usually
    aligned to regions.

Consequence:
    This would cause Markers not be generated on global map. Markers would be
    only generated in cropped area.

Fix:
    World::getRegionNoCrop() method is added, that does not apply world crop.
    This method is then used when updating regions into cache.

Result:
    Markers are generated correctly respecting their worl they are displayed on.
    And cache is updated correctly for regions that are cropped in some worlds.