### PR TITLE
FIX(mapcraft_markers) setting world crop after cache update

### DIFF
--- a/src/mapcrafter_markers.cpp
+++ b/src/mapcrafter_markers.cpp
@@ -68,7 +68,6 @@ Markers findMarkers(const config::MapcrafterConfig& config) {
 		mc::WorldCrop world_crop = world_it->second.getWorldCrop();
 		mc::World world(world_it->second.getInputDir().string(),
 				world_it->second.getDimension());
-		world.setWorldCrop(world_crop);
 		if (!world.load()) {
 			LOG(ERROR) << "Unable to load world " << world_it->first << "!";
 			continue;
@@ -78,6 +77,10 @@ Markers findMarkers(const config::MapcrafterConfig& config) {
 		mc::WorldEntitiesCache entities(world);
 		util::LogOutputProgressHandler progress;
 		entities.update(&progress);
+
+		// Setting world crop after WorldEntitiesCache is fully updated
+		// to allow markers of the same non-cropped world to be generated
+		world.setWorldCrop(world_crop);
 
 		// use name of the world section as world name, not the world_name
 		std::string world_name = world_it->second.getShortName();


### PR DESCRIPTION
Cause:
    If render.conf contains multiple definitions of the same world with different
    crop setting it would cause cache to mistakenly update timestamp on whole
    region but some entities would left out because of cropping.

Consequence:
    This would cause Markers not be generated on global map. Markers would be
    only generated in cropped area.

Fix:
    When syncing world data with cache, crop is not applied. This way, world
    get correctly synced into cache on the first pass completely.

Result:
    Markers are generated correctly respecting their world they are displayed on.
    And cache is updated correctly for regions that are cropped in some worlds.
    First pass can take significant time, but any subsequent pass is instant
    beacause whole world is in cache (if you are using multiple world definitions
    with same world data, e.g. views)

    This would cause unnecessary work being done on worlds that have only cropped
    view of their world.