### PR TITLE
Drop png timestamps

### DIFF
--- a/src/tools/mapcrafter_textures.py
+++ b/src/tools/mapcrafter_textures.py
@@ -142,12 +142,12 @@ if __name__ == "__main__":
 	else:
 		for filename in glob.glob(os.path.join(args["outdir"], "blocks", "hardened_clay*.png")):
 			if os.path.exists(filename):
-				subprocess.check_call(["convert", filename, filename])
+				subprocess.check_call(["convert", "-strip", filename, filename])
 		
 		filename = os.path.join(args["outdir"], "blocks", "red_sand.png")
 		if os.path.exists(filename):
-			subprocess.check_call(["convert", filename, filename])
+			subprocess.check_call(["convert", "-strip", filename, filename])
 		
 		filename = os.path.join(args["outdir"], "blocks", "glass_pane_top_white.png")
 		if os.path.exists(filename):
-			subprocess.check_call(["convert", filename, "-type", "TrueColorMatte", "-define", "png:color-type=6", filename])
+			subprocess.check_call(["convert", "-strip", filename, "-type", "TrueColorMatte", "-define", "png:color-type=6", filename])


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

Needed, because convert does not generate reproducible output by default:
https://github.com/ImageMagick/ImageMagick/pull/1270


This PR was done while working on reproducible builds for openSUSE.