### PR TITLE
Fix edge case of palette size being smaller than dataset

### DIFF
--- a/src/mapcraftercore/mc/chunk.cpp
+++ b/src/mapcraftercore/mc/chunk.cpp
@@ -116,13 +116,10 @@ void readPackedShorts(const std::vector<int64_t>& data, uint16_t* palette) {
 	assert(j == 16*16*16);
 }
 
-void readPackedShorts_v116(const std::vector<int64_t>& data, uint16_t* palette, uint32_t num_palette) {
-	uint32_t bits_per_value = 4;
-	while ((1 << bits_per_value) < num_palette) {
-		bits_per_value += 1;
-	}
+void readPackedShorts_v116(const std::vector<int64_t>& data, uint16_t* palette) {
+	uint32_t shorts_per_long = (4096 + data.size() - 1) / data.size();
+	uint32_t bits_per_value = 64 / shorts_per_long;
 	std::fill(palette, &palette[4096], 0);
-	uint32_t shorts_per_long = 64 / bits_per_value;
 	uint16_t mask = (1 << bits_per_value) - 1;
 
 	for (uint32_t i=0; i<shorts_per_long; i++) {
@@ -280,7 +277,7 @@ bool Chunk::readNBT(mc::BlockStateRegistry& block_registry, const char* data, si
 		section.y = y.payload;
 
 		if (data_version >= 2529){
-			readPackedShorts_v116(blockstates.payload, section.block_ids, palette.payload.size());
+			readPackedShorts_v116(blockstates.payload, section.block_ids);
 		} else {
 			readPackedShorts(blockstates.payload, section.block_ids);
 		}


### PR DESCRIPTION
This could produce issues like that in the world.
![Screen Shot 2020-07-12 at 00 54 11](https://user-images.githubusercontent.com/11891522/87239455-55080880-c3dd-11ea-9b55-2d59d2910d80.png)

With this fix it seems to get rid of all of those issues.
![Screen Shot 2020-07-12 at 01 33 05](https://user-images.githubusercontent.com/11891522/87239664-b4671800-c3df-11ea-86ed-2cc5f4541774.png)
