### PR TITLE
improved alpha handing for texture blur

### DIFF
--- a/src/mapcraftercore/renderer/image.cpp
+++ b/src/mapcraftercore/renderer/image.cpp
@@ -439,13 +439,13 @@ RGBAPixel blurKernel(const RGBAImage& image, int x, int y, int radius) {
 			if (x2 < 0 || y2 < 0 || x2 >= image.getWidth() || y2 >= image.getHeight())
 				continue;
 			RGBAPixel pixel = image.getPixel(x2, y2);
-			r += rgba_red(pixel);
-			g += rgba_green(pixel);
-			b += rgba_blue(pixel);
+			r += (int) rgba_red(pixel) * (int) rgba_alpha(pixel);
+			g += (int) rgba_green(pixel) * (int) rgba_alpha(pixel);
+			b += (int) rgba_blue(pixel) * (int) rgba_alpha(pixel);
 			a += rgba_alpha(pixel);
 			count++;
 		}
-	return rgba(r / count, g / count, b / count, a / count);
+	return a ? rgba(r / a, g / a, b / a, a / count) : 0;
 }
 
 void RGBAImage::blur(RGBAImage& dest, int radius) const {


### PR DESCRIPTION
The existing texture blur code doesn't take the alpha level into account. This results in blocks such as leaves being discolored, as the "black" pixels between the leaves are being included in the average despite the fact that they're fully transparent.

Reference image (no blur):
![no-blur](https://user-images.githubusercontent.com/11216106/155978817-3a838fd8-589c-4792-a204-774ad0d19730.png)

Old behavior (`texture_blur = 1`):
![blur-original](https://user-images.githubusercontent.com/11216106/155978871-e3a9f303-5ba0-456f-9e7c-90571030e889.png)

Fixed behavior (`texture_blur = 1`):
![blur-fixed](https://user-images.githubusercontent.com/11216106/155978897-f566f668-4b26-4f7e-aac8-51d646f73426.png)
