### PR TITLE
Fix build with Boost 1.85.0

### DIFF
--- a/src/mapcraftercore/renderer/tilerenderworker.cpp
+++ b/src/mapcraftercore/renderer/tilerenderworker.cpp
@@ -72,8 +72,8 @@ void TileRenderWorker::saveTile(const TilePath& tile, const RGBAImage& image) {
 	if (tile.getDepth() == 0)
 		filename = std::string("base") + suffix;
 	fs::path file = render_context.output_dir / filename;
-	if (!fs::exists(file.branch_path()))
-		fs::create_directories(file.branch_path());
+	if (!fs::exists(file.parent_path()))
+		fs::create_directories(file.parent_path());
 
 	if ((png && !png_indexed) && !image.writePNG(file.string()))
 		LOG(WARNING) << "Unable to write '" << file.string() << "'.";


### PR DESCRIPTION
Fix build failure with Boost 1.85.0:
```
/tmp/mapcrafter-20240425-1036-e8d8gu/mapcrafter-v.2.4/src/mapcraftercore/renderer/tilerenderworker.cpp:75:23: error: no member named 'branch_path' in 'boost::filesystem::path'
        if (!fs::exists(file.branch_path()))
                        ~~~~ ^
```

This is due to removed APIs, i.e. https://www.boost.org/doc/libs/1_85_0/libs/filesystem/doc/deprecated.html

`branch_path()` has been deprecated and essentially an alias for `parent_path()` since Boost 1.36.0 (from 2008) - https://www.boost.org/doc/libs/1_36_0/boost/filesystem/path.hpp
```hpp
# ifndef BOOST_FILESYSTEM_NO_DEPRECATED
      string_type  leaf() const { return filename(); }
      basic_path   branch_path() const { return parent_path(); }
# endif
```

If older Boost (e.g. 1.35.0) is needed, then may have to use a version check.

---

Seen while update Boost in Homebrew - https://github.com/Homebrew/homebrew-core/pull/169237